### PR TITLE
Upgrade node-local-dns to 1.22.20

### DIFF
--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.21.1
+appVersion: 1.22.20

--- a/charts/node-local-dns/README.md
+++ b/charts/node-local-dns/README.md
@@ -1,6 +1,6 @@
 # node-local-dns
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.1](https://img.shields.io/badge/AppVersion-1.21.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.22.20](https://img.shields.io/badge/AppVersion-1.22.20-informational?style=flat-square)
 
 NodeLocal DNSCache improves Cluster DNS performance by running a dns caching agent on cluster nodes as a DaemonSet.
 
@@ -28,7 +28,7 @@ helm install node-local-dns quortex-public/node-local-dns -n kube-system
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Helm's name computing override. |
 | fullnameOverride | string | `""` | Helm's fullname computing override. |
-| image.repository | string | `"k8s.gcr.io/dns/k8s-dns-node-cache"` | node-local-dns image repository. |
+| image.repository | string | `"registry.k8s.io/dns/k8s-dns-node-cache"` | node-local-dns image repository. |
 | image.pullPolicy | string | `"IfNotPresent"` | node-local-dns container image pull policy. |
 | image.tag | string | `""` | node-local-dns image tag (default is the chart appVersion). |
 | imagePullSecrets | list | `[]` | A list of secrets used to pull containers images. |
@@ -37,7 +37,7 @@ helm install node-local-dns quortex-public/node-local-dns -n kube-system
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"10%"}}` | An update strategy to replace existing DaemonSet pods with new pods. |
 | priorityClassName | string | `"system-node-critical"` | If specified, indicates the pod's priority. |
-| securityContext | object | `{"privileged":true}` | node-local-dns container security context. |
+| securityContext | object | `{"capabilities":{"add":["NET_ADMIN"]}}` | node-local-dns container security context. |
 | resources | object | `{"requests":{"cpu":"25m","memory":"5Mi"}}` | node-local-dns resources. |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"}]` | Node tolerations for scheduling to nodes with taints. |
@@ -48,7 +48,7 @@ helm install node-local-dns quortex-public/node-local-dns -n kube-system
 | config.localDns | string | `"169.254.20.10"` | localDns is the local listen IP address chosen for NodeLocal DNSCache. |
 | config.dnsServer | string | `""` | The dns server address Could be retrieved with `kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}` |
 | config.clusterDomain | string | `"cluster.local"` | The cluster domain |
-| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator. https://github.com/coreos/prometheus-operator |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator. https://github.com/coreos/prometheus-operator  |
 | serviceMonitor.scheme | string | `"http"` | HTTP scheme to use for scraping. |
 | serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor. |
 | serviceMonitor.interval | string | `"15s"` | Interval at which metrics should be scraped. |

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -37,7 +37,9 @@ priorityClassName: system-node-critical
 
 # -- node-local-dns container security context.
 securityContext:
-  privileged: true
+  capabilities:
+    add:
+    - NET_ADMIN
 
 # -- node-local-dns resources.
 resources:


### PR DESCRIPTION
The 1.22.23 is out, but I chose to based the update onto the recommended file : https://github.com/kubernetes/kubernetes/blob/v1.27.3/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml

Fyi I used [dyff](https://github.com/homeport/dyff) to diff the two versions I used : 
```
dyff between https://raw.githubusercontent.com/kubernetes/kubernetes/v1.24.15/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml https://raw.githubusercontent.com/kubernetes/kubernetes/v1.27.3/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml

     _        __  __
   _| |_   _ / _|/ _|  between https://raw.githubusercontent.com/kubernetes/kubernetes/v1.24.15/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml, five documents
 / _' | | | | |_| |_       and https://raw.githubusercontent.com/kubernetes/kubernetes/v1.27.3/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml, five documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned two differences
        |___/

spec.template.spec.containers.node-cache.image  (DaemonSet/kube-system/node-local-dns)
  ± value change
    - k8s.gcr.io/dns/k8s-dns-node-cache:1.21.1
    + registry.k8s.io/dns/k8s-dns-node-cache:1.22.20

spec.template.spec.containers.node-cache.securityContext  (DaemonSet/kube-system/node-local-dns)
  - one map entry removed:     + one map entry added:
    privileged: true             capabilities:
                                 │ add:
                                 │ - NET_ADMIN
```